### PR TITLE
Add expiration_date for .nl TLD

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -373,6 +373,19 @@ class TestParser(unittest.TestCase):
         }
         self._parse_and_compare('utwente.nl', data, expected_results)
 
+    def test_nl_expiration(self):
+        data = """
+        domain_name: randomtest.nl
+        Status:      in quarantine
+        Creation Date: 2008-09-24
+        Updated Date: 2020-10-27
+        Date out of quarantine: 2020-12-06T20:31:25
+        """
+
+        w = WhoisEntry.load('randomtest.nl', data)
+        expires = w.expiration_date.strftime('%Y-%m-%d')
+        self.assertEqual(expires, '2020-12-06')
+
     def test_dk_parse(self):
         data = """
 #

--- a/whois/parser.py
+++ b/whois/parser.py
@@ -44,6 +44,7 @@ KNOWN_FORMATS = [
     '%Y.%m.%d %H:%M:%S',        # 2014.03.08 10:28:24
     '%d-%b-%Y %H:%M:%S %Z',     # 24-Jul-2009 13:20:03 UTC
     '%a %b %d %H:%M:%S %Z %Y',  # Tue Jun 21 23:59:59 GMT 2011
+    '%Y-%m-%dT%H:%M:%S',        # 2007-01-26T19:10:31
     '%Y-%m-%dT%H:%M:%SZ',       # 2007-01-26T19:10:31Z
     '%Y-%m-%dT%H:%M:%S.%fZ',    # 2018-12-01T16:17:30.568Z
     '%Y-%m-%dT%H:%M:%S%z',      # 2013-12-06T08:17:22-0800
@@ -525,7 +526,7 @@ class WhoisNl(WhoisEntry):
         """
     regex = {
         'domain_name':         r'Domain Name: *(.+)',
-        'expiration_date':     None,
+        'expiration_date':     r'Date\sout\sof\squarantine:\s*(.+)',
         'updated_date':        r'Updated\sDate:\s*(.+)',
         'creation_date':       r'Creation\sDate:\s*(.+)',
         'status':              r'Status: *(.+)',  # list of statuses


### PR DESCRIPTION
All domains in .nl TLD become quarantined for 40 days upon cancellation.
This makes it effectively the expiration date.

For more information, have a look at:
https://www.sidn.nl/en/news-and-blogs/quarantine-period-end-times-to-be-shown-in-whois